### PR TITLE
HoistFail

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -73,16 +73,6 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -13,9 +13,7 @@ cabal-version:       >=1.10
 
 extra-source-files:  changelog.md
 
-tested-with:         GHC == 7.8.4
-                   , GHC == 7.10.3
-                   , GHC == 8.0.2
+tested-with:         GHC == 8.0.2
                    , GHC == 8.2.2
                    , GHC == 8.4.4
                    , GHC == 8.6.5
@@ -34,7 +32,7 @@ source-repository head
 library
   exposed-modules:     Control.Monad.Error.Hoist
                      , Control.Monad.Fail.Hoist
-  build-depends:       base   >=4.7 && <4.18
+  build-depends:       base   >=4.9 && <4.18
                      , mtl    >=2.1 && <2.3
                      , either >=4   && <6
 

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -1,5 +1,5 @@
 name:                hoist-error
-version:             0.2.2.0
+version:             0.2.3.0
 synopsis:            Some convenience facilities for hoisting errors into a monad
 description:         Provides a typeclass and useful combinators for hoisting errors into a monad.
 license:             MIT
@@ -33,6 +33,7 @@ source-repository head
 
 library
   exposed-modules:     Control.Monad.Error.Hoist
+                     , Control.Monad.Fail.Hoist
   build-depends:       base   >=4.7 && <4.18
                      , mtl    >=2.1 && <2.3
                      , either >=4   && <6

--- a/src/Control/Monad/Error/Hoist.hs
+++ b/src/Control/Monad/Error/Hoist.hs
@@ -70,9 +70,9 @@ class Monad m => HoistError m t e e' | t -> e where
   -- computation into @m@.
   --
   -- @
-  -- 'hoistError' :: 'MonadError' e m -> (() -> e) -> 'Maybe'       a -> m a
-  -- 'hoistError' :: 'MonadError' e m -> (a  -> e) -> 'Either'  a   b -> m b
-  -- 'hoistError' :: 'MonadError' e m -> (a  -> e) -> 'ExceptT' a m b -> m b
+  -- 'hoistError' :: 'MonadError' e m => (() -> e) -> 'Maybe'       a -> m a
+  -- 'hoistError' :: 'MonadError' e m => (a  -> e) -> 'Either'  a   b -> m b
+  -- 'hoistError' :: 'MonadError' e m => (a  -> e) -> 'ExceptT' a m b -> m b
   -- @
   hoistError
     :: (e -> e')

--- a/src/Control/Monad/Error/Hoist.hs
+++ b/src/Control/Monad/Error/Hoist.hs
@@ -153,9 +153,7 @@ hoistErrorM
   => (e -> e')
   -> m (t a)
   -> m a
-hoistErrorM e m = do
-  x <- m
-  hoistError e x
+hoistErrorM e m = hoistError e =<< m
 
 -- | A version of 'hoistError'' that operates on values already in the monad.
 --
@@ -168,9 +166,7 @@ hoistErrorM'
   :: HoistError m t e e
   => m (t a)
   -> m a
-hoistErrorM' m = do
-  x <- m
-  hoistError' x
+hoistErrorM' m = hoistError' =<< m
 
 -- | A version of 'hoistErrorE' that operates on values already in the monad.
 hoistErrorEM
@@ -251,9 +247,7 @@ infixl 8 <?>
   => m (t a)
   -> e'
   -> m a
-m <!?> e = do
-  x <- m
-  x <?> e
+m <!?> e = hoistError (const e) =<< m
 
 infixl 8 <!?>
 {-# INLINE (<!?>) #-}

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -16,7 +16,9 @@ module Control.Monad.Fail.Hoist
   , (<!>)
   ) where
 
-import           Control.Monad.Error.Class  (MonadError (..))
+import           Prelude hiding (fail)
+
+import           Control.Monad.Fail         (MonadFail (..))
 
 import           Data.Either                (Either, either)
 

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -18,7 +18,7 @@ import           Control.Monad.Error.Class  (MonadError (..))
 
 import           Data.Either                (Either, either)
 
-class Monad m => HoistFail m t e | t -> e where
+class Monad m => HoistFail t m e | t -> e where
 
   -- | Given a conversion from the error in @t a@ to @String@, we can hoist the
   -- computation into @m@.
@@ -32,13 +32,13 @@ class Monad m => HoistFail m t e | t -> e where
     -> t a
     -> m a
 
-instance MonadFail m => HoistFail m Maybe () where
+instance MonadFail m => HoistFail Maybe m () where
   hoistFail f = maybe (fail $ f ()) pure
 
-instance MonadFail m => HoistFail m (Either e) e where
+instance MonadFail m => HoistFail (Either e) m e where
   hoistFail f = either (fail . f) pure
 
-hoistFail_ :: HoistFail m t String => t a -> m a
+hoistFail_ :: HoistFail t m String => t a -> m a
 hoistFail_ = hoistFail id
 
 -- | A flipped synonym for 'hoistFail'.
@@ -48,7 +48,7 @@ hoistFail_ = hoistFail id
 -- ('<%!>') :: 'MonadFail' m => 'Either'  a   b -> (a  -> e) ->           m b
 -- @
 (<%!>)
-  :: HoistFail m t e
+  :: HoistFail t m e
   => t a
   -> (e -> String)
   -> m a
@@ -65,7 +65,7 @@ infixl 8 <%!>
 -- ('<!>') :: 'MonadFail' m => 'Either'  a   b -> e ->           m b
 -- @
 (<!>)
-  :: HoistFail m t e
+  :: HoistFail t m e
   => t a
   -> String
   -> m a

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE CPP                    #-}
+{-# LANGUAGE FlexibleInstances      #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs                  #-}
+{-# LANGUAGE MultiParamTypeClasses  #-}
+
+-- | 'HoistFail extends 'MonadFail with 'hoistFail, which enables lifting
+-- of partiality types such as 'Maybe' and @'Either' e@ into the monad.
+module Control.Monad.Fail.Hoist
+  ( HoistFail(..)
+  , (<%!>)
+  , (<!>)
+  ) where
+
+import           Control.Monad.Error.Class  (MonadError (..))
+
+import           Data.Either                (Either, either)
+
+class Monad m => HoistFail m t e | t -> e where
+
+  -- | Given a conversion from the error in @t a@ to @String@, we can hoist the
+  -- computation into @m@.
+  --
+  -- @
+  -- 'hoistFail' :: 'MonadFail' m => (() -> e) -> 'Maybe'       a -> m a
+  -- 'hoistFail' :: 'MonadFail' m => (a  -> e) -> 'Either'  a   b -> m b
+  -- @
+  hoistFail
+    :: (e -> String)
+    -> t a
+    -> m a
+
+instance MonadFail m => HoistFail m Maybe () where
+  hoistFail f = maybe (fail $ f ()) pure
+
+instance MonadFail m => HoistFail m (Either e) e where
+  hoistFail f = either (fail . f) pure
+
+-- | A flipped synonym for 'hoistFail'.
+--
+-- @
+-- ('<%!>') :: 'MonadFail' m => 'Maybe'       a -> (() -> e) ->           m a
+-- ('<%!>') :: 'MonadFail' m => 'Either'  a   b -> (a  -> e) ->           m b
+-- @
+(<%!>)
+  :: HoistFail m t e
+  => t a
+  -> (e -> String)
+  -> m a
+(<%!>) = flip hoistFail
+
+infixl 8 <%!>
+{-# INLINE (<%!>) #-}
+
+-- | A version of '<%!>' that ignores the error in @t a@ and replaces it
+-- with a new one.
+--
+-- @
+-- ('<!>') :: 'MonadFail' m => 'Maybe'       a -> e ->           m a
+-- ('<!>') :: 'MonadFail' m => 'Either'  a   b -> e ->           m b
+-- @
+(<!>)
+  :: HoistFail m t e
+  => t a
+  -> String
+  -> m a
+m <!> e = m <%!> const e
+
+infixl 8 <!>
+{-# INLINE (<!>) #-}

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -117,9 +117,7 @@ hoistFailM
   => (e -> String)
   -> m (t a)
   -> m a
-hoistFailM e m = do
-  x <- m
-  hoistFail e x
+hoistFailM e m = hoistFail e =<< m
 
 -- | A version of 'hoistFail'' that operates on values already in the monad.
 --
@@ -132,9 +130,7 @@ hoistFailM'
   :: HoistFail m t String
   => m (t a)
   -> m a
-hoistFailM' m = do
-  x <- m
-  hoistFail' x
+hoistFailM' m = hoistFail' =<< m
 
 -- | A version of 'hoistFailE' that operates on values already in the monad.
 hoistFailEM
@@ -213,9 +209,7 @@ infixl 8 <#>
   => m (t a)
   -> String
   -> m a
-m <!#> e = do
-  x <- m
-  x <#> e
+m <!#> e = hoistFail (const e) =<< m
 
 infixl 8 <!#>
 {-# INLINE (<!#>) #-}

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -9,8 +9,7 @@
 -- of partiality types such as 'Maybe' and @'Either' e@ into the monad.
 module Control.Monad.Fail.Hoist
   ( HoistFail(..)
-  , hoistFailShow
-  , hoistFailString
+  , hoistFail_
   , (<%!>)
   , (<!>)
   ) where
@@ -39,11 +38,8 @@ instance MonadFail m => HoistFail m Maybe () where
 instance MonadFail m => HoistFail m (Either e) e where
   hoistFail f = either (fail . f) pure
 
-hoistFailShow :: (HoistFail m t e, Show e) => t a -> m a
-hoistFailShow = hoistFail show
-
-hoistFailString :: HoistFail m t String => t a -> m a
-hoistFailString = hoistFail id
+hoistFail_ :: HoistFail m t String => t a -> m a
+hoistFail_ = hoistFail id
 
 -- | A flipped synonym for 'hoistFail'.
 --

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -10,6 +10,8 @@
 module Control.Monad.Fail.Hoist
   ( HoistFail(..)
   , hoistFail_
+  , hoistFailE
+  , hoistFailE_
   , (<%!>)
   , (<!>)
   ) where
@@ -40,6 +42,12 @@ instance MonadFail m => HoistFail (Either e) m e where
 
 hoistFail_ :: HoistFail t m String => t a -> m a
 hoistFail_ = hoistFail id
+
+hoistFailE :: MonadFail m => (e -> String) -> Either e a -> m a
+hoistFailE = hoistFail
+
+hoistFailE_ :: MonadFail m => Either String a -> m a
+hoistFailE_ = hoistFail_
 
 -- | A flipped synonym for 'hoistFail'.
 --

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP                    #-}
+{-# LANGUAGE FlexibleContexts       #-}
 {-# LANGUAGE FlexibleInstances      #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs                  #-}
@@ -8,6 +9,8 @@
 -- of partiality types such as 'Maybe' and @'Either' e@ into the monad.
 module Control.Monad.Fail.Hoist
   ( HoistFail(..)
+  , hoistFailShow
+  , hoistFailString
   , (<%!>)
   , (<!>)
   ) where
@@ -35,6 +38,12 @@ instance MonadFail m => HoistFail m Maybe () where
 
 instance MonadFail m => HoistFail m (Either e) e where
   hoistFail f = either (fail . f) pure
+
+hoistFailShow :: (HoistFail m t e, Show e) => t a -> m a
+hoistFailShow = hoistFail show
+
+hoistFailString :: HoistFail m t String => t a -> m a
+hoistFailString = hoistFail id
 
 -- | A flipped synonym for 'hoistFail'.
 --

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -188,7 +188,7 @@ infixl 8 <%!#>
 -- ('<#>') :: 'MonadFail' m => 'Either'  a   b -> String ->           m b
 -- @
 (<#>)
-  :: HoistFail m t String
+  :: HoistFail m t e
   => t a
   -> String
   -> m a
@@ -205,7 +205,7 @@ infixl 8 <#>
 -- ('<!#>') :: 'MonadFail m =>    'ExceptT' a m b  -> String -> 'ExceptT' a m b
 -- @
 (<!#>)
-  :: HoistFail m t String
+  :: HoistFail m t e
   => m (t a)
   -> String
   -> m a

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -12,15 +12,35 @@ module Control.Monad.Fail.Hoist
   , hoistFail'
   , hoistFailE
   , hoistFailE'
+  , hoistFailM
+  , hoistFailM'
+  , hoistFailEM
+  , hoistFailEM'
   , (<%#>)
+  , (<%!#>)
   , (<#>)
+  , (<!#>)
   ) where
 
 import           Prelude hiding (fail)
 
+import           Control.Monad              ((<=<))
 import           Control.Monad.Fail         (MonadFail (..))
 
 import           Data.Either                (Either, either)
+
+#if MIN_VERSION_mtl(2,2,2)
+import           Control.Monad.Except       (Except, ExceptT, runExcept,
+                                             runExceptT)
+#else
+import           Control.Monad.Error        (Error, ErrorT, runErrorT)
+#endif
+
+#if MIN_VERSION_either(5,0,0)
+-- Control.Monad.Trans.Either was removed from @either@ in version 5.
+#else
+import           Control.Monad.Trans.Either (EitherT, eitherT, runEitherT)
+#endif
 
 class Monad m => HoistFail t m e | t -> e where
 
@@ -37,10 +57,29 @@ class Monad m => HoistFail t m e | t -> e where
     -> m a
 
 instance MonadFail m => HoistFail Maybe m () where
-  hoistFail f = maybe (fail $ f ()) pure
+  hoistFail f = maybe (fail $ f ()) return
 
 instance MonadFail m => HoistFail (Either e) m e where
-  hoistFail f = either (fail . f) pure
+  hoistFail f = either (fail . f) return
+
+#if MIN_VERSION_either(5,0,0)
+-- Control.Monad.Trans.Either was removed from @either@ in version 5.
+#else
+instance (m ~ n, MonadFail m) => HoistFail (EitherT e n) m e where
+  hoistFail f = eitherT (fail . f) return
+#endif
+
+#if MIN_VERSION_mtl(2,2,2)
+instance MonadFail m => HoistFail (Except e) m e where
+  hoistFail f = either (fail . f) return . runExcept
+
+instance MonadFail m => HoistFail (ExceptT e m) m e where
+  hoistFail f = either (fail . f) return <=< runExceptT
+#else
+-- 'ErrorT' was renamed to 'ExceptT' in mtl 2.2.2
+instance MonadError m => HoistFail (ErrorT e m) m e where
+  hoistFail f = either (fail . f) return <=< runErrorT
+#endif
 
 hoistFail' :: HoistFail t m String => t a -> m a
 hoistFail' = hoistFail id
@@ -50,6 +89,36 @@ hoistFailE = hoistFail
 
 hoistFailE' :: MonadFail m => Either String a -> m a
 hoistFailE' = hoistFail'
+
+hoistFailM
+  :: HoistFail t m e
+  => (e -> String)
+  -> m (t a)
+  -> m a
+hoistFailM e m = do
+  x <- m
+  hoistFail e x
+
+hoistFailM'
+  :: HoistFail t m String
+  => m (t a)
+  -> m a
+hoistFailM' m = do
+  x <- m
+  hoistFail' x
+
+hoistFailEM
+  :: MonadFail m
+  => (e -> String)
+  -> m (Either e a)
+  -> m a
+hoistFailEM = hoistFailM
+
+hoistFailEM'
+  :: MonadFail m
+  => m (Either String a)
+  -> m a
+hoistFailEM' = hoistFailM'
 
 -- | A flipped synonym for 'hoistFail'.
 --
@@ -67,15 +136,32 @@ hoistFailE' = hoistFail'
 infixl 8 <%#>
 {-# INLINE (<%#>) #-}
 
+-- | A flipped synonym for 'hoistFailM'.
+--
+-- @
+-- ('<%!#>') :: 'MonadError' e m => m ('Maybe'       a) -> (() -> e) ->           m a
+-- ('<%!#>') :: 'MonadError' e m => m ('Either'  a   b) -> (a  -> e) ->           m b
+-- ('<%!#>') :: 'MonadError' e m =>    'ExceptT' a m b  -> (a  -> e) -> 'ExceptT' a m b
+-- @
+(<%!#>)
+  :: HoistFail t m e
+  => m (t a)
+  -> (e -> String)
+  -> m a
+(<%!#>) = flip hoistFailM
+
+infixl 8 <%!#>
+{-# INLINE (<%!#>) #-}
+
 -- | A version of '<%#>' that ignores the error in @t a@ and replaces it
 -- with a new one.
 --
 -- @
--- ('<#>') :: 'MonadFail' m => 'Maybe'       a -> e ->           m a
--- ('<#>') :: 'MonadFail' m => 'Either'  a   b -> e ->           m b
+-- ('<#>') :: 'MonadFail' m => 'Maybe'       a -> String ->           m a
+-- ('<#>') :: 'MonadFail' m => 'Either'  a   b -> String ->           m b
 -- @
 (<#>)
-  :: HoistFail t m e
+  :: HoistFail t m String
   => t a
   -> String
   -> m a
@@ -83,3 +169,22 @@ m <#> e = m <%#> const e
 
 infixl 8 <#>
 {-# INLINE (<#>) #-}
+
+-- | A version of '<#>' that operates on values already in the monad.
+--
+-- @
+-- ('<!#>') :: 'MonadFail m => m ('Maybe'       a) -> String ->           m a
+-- ('<!#>') :: 'MonadFail m => m ('Either'  a   b) -> String ->           m b
+-- ('<!#>') :: 'MonadFail m =>    'ExceptT' a m b  -> String -> 'ExceptT' a m b
+-- @
+(<!#>)
+  :: HoistFail t m String
+  => m (t a)
+  -> String
+  -> m a
+m <!#> e = do
+  x <- m
+  x <#> e
+
+infixl 8 <!#>
+{-# INLINE (<!#>) #-}

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -9,11 +9,11 @@
 -- of partiality types such as 'Maybe' and @'Either' e@ into the monad.
 module Control.Monad.Fail.Hoist
   ( HoistFail(..)
-  , hoistFail_
+  , hoistFail'
   , hoistFailE
-  , hoistFailE_
-  , (<%!>)
-  , (<!>)
+  , hoistFailE'
+  , (<%#>)
+  , (<#>)
   ) where
 
 import           Prelude hiding (fail)
@@ -42,44 +42,44 @@ instance MonadFail m => HoistFail Maybe m () where
 instance MonadFail m => HoistFail (Either e) m e where
   hoistFail f = either (fail . f) pure
 
-hoistFail_ :: HoistFail t m String => t a -> m a
-hoistFail_ = hoistFail id
+hoistFail' :: HoistFail t m String => t a -> m a
+hoistFail' = hoistFail id
 
 hoistFailE :: MonadFail m => (e -> String) -> Either e a -> m a
 hoistFailE = hoistFail
 
-hoistFailE_ :: MonadFail m => Either String a -> m a
-hoistFailE_ = hoistFail_
+hoistFailE' :: MonadFail m => Either String a -> m a
+hoistFailE' = hoistFail'
 
 -- | A flipped synonym for 'hoistFail'.
 --
 -- @
--- ('<%!>') :: 'MonadFail' m => 'Maybe'       a -> (() -> e) ->           m a
--- ('<%!>') :: 'MonadFail' m => 'Either'  a   b -> (a  -> e) ->           m b
+-- ('<%#>') :: 'MonadFail' m => 'Maybe'       a -> (() -> e) ->           m a
+-- ('<%#>') :: 'MonadFail' m => 'Either'  a   b -> (a  -> e) ->           m b
 -- @
-(<%!>)
+(<%#>)
   :: HoistFail t m e
   => t a
   -> (e -> String)
   -> m a
-(<%!>) = flip hoistFail
+(<%#>) = flip hoistFail
 
-infixl 8 <%!>
-{-# INLINE (<%!>) #-}
+infixl 8 <%#>
+{-# INLINE (<%#>) #-}
 
--- | A version of '<%!>' that ignores the error in @t a@ and replaces it
+-- | A version of '<%#>' that ignores the error in @t a@ and replaces it
 -- with a new one.
 --
 -- @
--- ('<!>') :: 'MonadFail' m => 'Maybe'       a -> e ->           m a
--- ('<!>') :: 'MonadFail' m => 'Either'  a   b -> e ->           m b
+-- ('<#>') :: 'MonadFail' m => 'Maybe'       a -> e ->           m a
+-- ('<#>') :: 'MonadFail' m => 'Either'  a   b -> e ->           m b
 -- @
-(<!>)
+(<#>)
   :: HoistFail t m e
   => t a
   -> String
   -> m a
-m <!> e = m <%!> const e
+m <#> e = m <%#> const e
 
-infixl 8 <!>
-{-# INLINE (<!>) #-}
+infixl 8 <#>
+{-# INLINE (<#>) #-}


### PR DESCRIPTION
Adds a new typeclass `HoistFail` analogous to `HoistError` but for hoisting into `MonadFail`. This is concretely useful for writing aeson and cassava parsers; both of these libraries use `MonadFail` to support parse errors, and our parsers tend to be littered with variations of `either fail pure`.

To support common use cases I've added some functions with mnemonic suffixes:
- a family of functions ending with `'`, which simplify hoisting from different monads with the same error type
- a family of functions with `E` in the suffix, which set the input monad to `Either` to support hoisting from types where the monad is polymorphic.