### PR TITLE
Pluck error

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.16.3
+# version: 0.18.1
 #
-# REGENDATA ("0.16.3",["github","hoist-error.cabal"])
+# REGENDATA ("0.18.1",["github","hoist-error.cabal"])
 #
 name: Haskell-CI
 on:
@@ -28,6 +28,16 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.8.2
+            compilerKind: ghc
+            compilerVersion: 9.8.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.6.4
+            compilerKind: ghc
+            compilerVersion: 9.6.4
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.4.5
             compilerKind: ghc
             compilerVersion: 9.4.5
@@ -53,36 +63,6 @@ jobs:
             compilerVersion: 8.8.4
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.6.5
-            compilerKind: ghc
-            compilerVersion: 8.6.5
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.4
-            compilerKind: ghc
-            compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.2.2
-            compilerKind: ghc
-            compilerVersion: 8.2.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.0.2
-            compilerKind: ghc
-            compilerVersion: 8.0.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
       fail-fast: false
     steps:
       - name: apt
@@ -91,18 +71,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.19.2/x86_64-linux-ghcup-0.1.19.2 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.20.0/x86_64-linux-ghcup-0.1.20.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -116,17 +96,19 @@ jobs:
           echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
           HCDIR=/opt/$HCKIND/$HCVER
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
-            HC=$HOME/.ghcup/bin/$HCKIND-$HCVER
+            HC=$("$HOME/.ghcup/bin/ghcup" whereis ghc "$HCVER")
+            HCPKG=$(echo "$HC" | sed 's#ghc$#ghc-pkg#')
+            HADDOCK=$(echo "$HC" | sed 's#ghc$#haddock#')
             echo "HC=$HC" >> "$GITHUB_ENV"
-            echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
-            echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "HCPKG=$HCPKG" >> "$GITHUB_ENV"
+            echo "HADDOCK=$HADDOCK" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
@@ -209,8 +191,8 @@ jobs:
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_hoist_error}" >> cabal.project
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package hoist-error" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          echo "package hoist-error" >> cabal.project
+          echo "    ghc-options: -Werror=missing-methods" >> cabal.project
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(hoist-error)$/; }' >> cabal.project.local

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Hoist Error
 
-[![Build Status](https://travis-ci.org/qfpl/hs-hoist-error.svg?branch=master)](https://travis-ci.org/qfpl/hs-hoist-error)
+[![Haskell-CI](https://github.com/qfpl/hs-hoist-error/actions/workflows/haskell-ci.yml/badge.svg)](https://github.com/qfpl/hs-hoist-error/actions/workflows/haskell-ci.yml)
 
 A typeclass and some combinators to aid in the lifting of errors into your preferred context.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+0.3.0.0
+
+* Replaced the `HoistError` typeclass, which is about monads, with a
+  simpler `PluckError` typeclass that is about extracting errors from
+  values.
+* Introduced a parallel `Control.Monad.Fail.Hoist` module, for
+  hoisting error messages into `MonadFail`.
+
 0.2.1.0
 
 * Removed unicode syntax and variables

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -34,8 +34,7 @@ source-repository head
 library
   exposed-modules:     Control.Monad.Error.Hoist
   build-depends:       base   >=4.7 && <4.18
-                     , mtl    >=2.1 && <2.3
-                     , either >=4   && <6
+                     , mtl    >=2.2 && <2.3
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -18,6 +18,8 @@ tested-with:         GHC == 8.8.4
                    , GHC == 9.0.1
                    , GHC == 9.2.7
                    , GHC == 9.4.5
+                   , GHC == 9.6.4
+                   , GHC == 9.8.2
 
 source-repository head
     type: git
@@ -27,8 +29,8 @@ library
   exposed-modules:
     Control.Monad.Error.Hoist
     Control.Monad.Fail.Hoist
-  build-depends:       base   >=4.13 && <4.18
-                     , mtl    >=2.2 && <2.3
+  build-depends:       base   >=4.13 && <4.20
+                     , mtl    >=2.2 && <2.4
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -1,5 +1,5 @@
 name:                hoist-error
-version:             0.2.2.0
+version:             0.3.0.0
 synopsis:            Some convenience facilities for hoisting errors into a monad
 description:         Provides a typeclass and useful combinators for hoisting errors into a monad.
 license:             MIT
@@ -13,27 +13,21 @@ cabal-version:       >=1.10
 
 extra-source-files:  changelog.md
 
-tested-with:         GHC == 7.8.4
-                   , GHC == 7.10.3
-                   , GHC == 8.0.2
-                   , GHC == 8.2.2
-                   , GHC == 8.4.4
-                   , GHC == 8.6.5
-                   , GHC == 8.8.4
+tested-with:         GHC == 8.8.4
                    , GHC == 8.10.7
                    , GHC == 9.0.1
                    , GHC == 9.2.7
                    , GHC == 9.4.5
-
-
 
 source-repository head
     type: git
     location: https://github.com/alephcloud/hs-hoist-error.git
 
 library
-  exposed-modules:     Control.Monad.Error.Hoist
-  build-depends:       base   >=4.7 && <4.18
+  exposed-modules:
+    Control.Monad.Error.Hoist
+    Control.Monad.Fail.Hoist
+  build-depends:       base   >=4.13 && <4.18
                      , mtl    >=2.2 && <2.3
 
   hs-source-dirs:      src

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -39,7 +39,7 @@ hoistFail
   => (e -> String)
   -> t a
   -> m a
-hoistFail f t = inspectError t >>= either (fail . f) pure
+hoistFail f = foldError (fail . f) pure
 
 -- | Hoist computations whose error type is already 'String'.
 hoistFail' :: (PluckError String t m, MonadFail m) => t a -> m a

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-- | This module provides helpers for converting partiality types into
+-- 'MonadFail' computations.
+--
+-- 'MonadFail''s purpose is to handle pattern-match failures in
+-- @do@-expressions, and not to be a general-purpose error-handling
+-- mechanism. Despite this, some libraries use it as one, and this
+-- module can help you report errors via 'MonadFail'.
+--
+-- The operator mnemonics are the same as in
+-- "Control.Monad.Error.Hoist", but with @#@ in place of @?@. You can
+-- imagine a hastily-written @F@ looking kinda-sorta like a @#@, if it
+-- helps.
+
+module Control.Monad.Fail.Hoist
+  ( hoistFail
+  , hoistFail'
+  , hoistFailM
+  , hoistFailM'
+  -- ** Operators
+  , (<%#>)
+  , (<%!#>)
+  , (<#>)
+  , (<!#>)
+  ) where
+
+import           Control.Monad.Error.Hoist  (PluckError(..))
+
+-- | Given a conversion from the error in @t a@ to @String@, we can hoist the
+-- computation into @m@.
+--
+-- @
+-- 'hoistFail' :: 'MonadFail' m => (() -> String) -> 'Maybe'    a -> m a
+-- 'hoistFail' :: 'MonadFail' m => (a  -> String) -> 'Either' a b -> m b
+-- @
+hoistFail
+  :: (PluckError e t m, MonadFail m)
+  => (e -> String)
+  -> t a
+  -> m a
+hoistFail f t = inspectError t >>= either (fail . f) pure
+
+-- | Hoist computations whose error type is already 'String'.
+hoistFail' :: (PluckError String t m, MonadFail m) => t a -> m a
+hoistFail' = hoistFail id
+
+-- | A version of 'hoistFail' that operates on values already in the monad.
+--
+-- @
+-- 'hoistFailM' :: 'MonadFail' m => (() -> String) -> m ('Maybe'       a) ->           m a
+-- 'hoistFailM' :: 'MonadFail' m => (a  -> String) -> m ('Either'  a   b) ->           m b
+-- 'hoistFailM' :: 'MonadFail' m => (a  -> String) ->    'ExceptT' a m b  -> 'ExceptT' a m b
+-- @
+hoistFailM
+  :: (PluckError e t m, MonadFail m)
+  => (e -> String)
+  -> m (t a)
+  -> m a
+hoistFailM f m = m >>= hoistFail f
+
+-- | A version of 'hoistFail'' that operates on values already in the monad.
+--
+-- @
+-- 'hoistFailM'' :: 'MonadFail' m => m ('Maybe'       a) ->           m a
+-- 'hoistFailM'' :: 'MonadFail' m => m ('Either'  a   b) ->           m b
+-- 'hoistFailM'' :: 'MonadFail' m =>    'ExceptT' a m b  -> 'ExceptT' a m b
+-- @
+hoistFailM'
+  :: (PluckError String t m, MonadFail m)
+  => m (t a)
+  -> m a
+hoistFailM' = hoistFailM id
+
+-- | A flipped synonym for 'hoistFail'. Mnemonic: @#@ looks a bit like @F@
+--
+-- @
+-- ('<%#>') :: 'MonadFail' m => 'Maybe'    a -> (() -> e) -> m a
+-- ('<%#>') :: 'MonadFail' m => 'Either' a b -> (a  -> e) -> m b
+-- @
+(<%#>)
+  :: (PluckError e t m, MonadFail m)
+  => t a
+  -> (e -> String)
+  -> m a
+(<%#>) = flip hoistFail
+
+infixl 8 <%#>
+{-# INLINE (<%#>) #-}
+
+-- | A flipped synonym for 'hoistFailM'.
+--
+-- @
+-- ('<%!#>') :: 'MonadError' e m => m ('Maybe'       a) -> (() -> e) ->           m a
+-- ('<%!#>') :: 'MonadError' e m => m ('Either'  a   b) -> (a  -> e) ->           m b
+-- ('<%!#>') :: 'MonadError' e m =>    'ExceptT' a m b  -> (a  -> e) -> 'ExceptT' a m b
+-- @
+(<%!#>)
+  :: (PluckError e t m, MonadFail m)
+  => m (t a)
+  -> (e -> String)
+  -> m a
+(<%!#>) = flip hoistFailM
+
+infixl 8 <%!#>
+{-# INLINE (<%!#>) #-}
+
+-- | A version of '<%#>' that ignores the error in @t a@ and fails
+-- with a new one.
+--
+-- @
+-- ('<#>') :: 'MonadFail' m => 'Maybe'    a -> String -> m a
+-- ('<#>') :: 'MonadFail' m => 'Either' a b -> String -> m b
+-- @
+(<#>)
+  :: (PluckError e t m, MonadFail m)
+  => t a
+  -> String
+  -> m a
+m <#> e = m <%#> const e
+
+infixl 8 <#>
+{-# INLINE (<#>) #-}
+
+-- | A version of '<#>' that operates on values already in the monad.
+--
+-- @
+-- ('<!#>') :: 'MonadFail m => m ('Maybe'       a) -> String ->           m a
+-- ('<!#>') :: 'MonadFail m => m ('Either'  a   b) -> String ->           m b
+-- ('<!#>') :: 'MonadFail m =>    'ExceptT' a m b  -> String -> 'ExceptT' a m b
+-- @
+(<!#>)
+  :: (PluckError e t m, MonadFail m)
+  => m (t a)
+  -> String
+  -> m a
+m <!#> e = m >>= hoistFail (const e)
+
+infixl 8 <!#>
+{-# INLINE (<!#>) #-}


### PR DESCRIPTION
As discussed in https://github.com/qfpl/hs-hoist-error/pull/7#pullrequestreview-1601330000, replaces the typeclass which drives this library with a new one that's usable by both the `hoistError` and `hoistFail` instances, cleans up the haddocks a bit, and makes the package compatible with GHC 9.6 and 9.8 (and drops some ancient GHCs).

Closes #7.