### PR TITLE
Remove `instance PluckError e (Except e) m`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,9 @@
 * Replaced the `HoistError` typeclass, which is about monads, with a
   simpler `PluckError` typeclass that is about extracting errors from
   values.
+* Removed the instance for `Except e`, as it triggers overlapping
+  instance errors when attempting to hoist `ExceptT e m` for unknown
+  monads `m`.
 * Introduced a parallel `Control.Monad.Fail.Hoist` module, for
   hoisting error messages into `MonadFail`.
 

--- a/src/Control/Monad/Error/Hoist.hs
+++ b/src/Control/Monad/Error/Hoist.hs
@@ -194,7 +194,3 @@ instance Applicative m => PluckError e (Either e) m where
 instance Monad m => PluckError e (ExceptT e m) m where
   pluckError = runExceptT
   foldError f g = either f g <=< runExceptT
-
-instance Applicative m => PluckError e (Except e) m where
-  pluckError = pure . runExcept
-  foldError f g = either f g . runExcept


### PR DESCRIPTION
The presence of this instance causes overlapping instance errors when trying to hoist `ExceptT e m a` values for unknown `m`.

`Except e` is an alias for `ExceptT e Identity`, is isomorphic to `Either e`, and I don't think I've ever seen it in production code.