### PR TITLE
`hoistError'` and `hoistErrorM'`

### DIFF
--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -1,5 +1,5 @@
 name:                hoist-error
-version:             0.3.0.0
+version:             0.3.1.0
 synopsis:            Some convenience facilities for hoisting errors into a monad
 description:         Provides a typeclass and useful combinators for hoisting errors into a monad.
 license:             MIT

--- a/src/Control/Monad/Error/Hoist.hs
+++ b/src/Control/Monad/Error/Hoist.hs
@@ -36,7 +36,9 @@
 
 module Control.Monad.Error.Hoist
   ( hoistError
+  , hoistError'
   , hoistErrorM
+  , hoistErrorM'
   -- ** Operators
   -- $mnemonics
   , (<%?>)
@@ -70,6 +72,13 @@ hoistError
   -> m a
 hoistError f = foldError (throwError . f) pure
 
+-- | @hoistError' = hoistError id@
+hoistError'
+  :: (PluckError e t m, MonadError e m)
+  => t a
+  -> m a
+hoistError' = hoistError id
+
 -- | A version of 'hoistError' that operates on values already in the monad.
 --
 -- @
@@ -83,6 +92,13 @@ hoistErrorM
   -> m (t a)
   -> m a
 hoistErrorM e m = m >>= hoistError e
+
+-- | @hoistErrorM' = hoistErrorM id@
+hoistErrorM'
+  :: (PluckError e t m, MonadError e m)
+  => m (t a)
+  -> m a
+hoistErrorM' = hoistErrorM id
 
 -- $mnemonics
 --

--- a/src/Control/Monad/Fail/Hoist.hs
+++ b/src/Control/Monad/Fail/Hoist.hs
@@ -41,7 +41,7 @@ hoistFail
   -> m a
 hoistFail f = foldError (fail . f) pure
 
--- | Hoist computations whose error type is already 'String'.
+-- | @hoistFail' = hoistFail id@
 hoistFail' :: (PluckError String t m, MonadFail m) => t a -> m a
 hoistFail' = hoistFail id
 
@@ -59,13 +59,7 @@ hoistFailM
   -> m a
 hoistFailM f m = m >>= hoistFail f
 
--- | A version of 'hoistFail'' that operates on values already in the monad.
---
--- @
--- 'hoistFailM'' :: 'MonadFail' m => m ('Maybe'       a) ->           m a
--- 'hoistFailM'' :: 'MonadFail' m => m ('Either'  a   b) ->           m b
--- 'hoistFailM'' :: 'MonadFail' m =>    'ExceptT' a m b  -> 'ExceptT' a m b
--- @
+-- | @hoistFailM' = hoistFailM id@
 hoistFailM'
   :: (PluckError String t m, MonadFail m)
   => m (t a)


### PR DESCRIPTION
Resolves https://github.com/alephcloud/hs-hoist-error/issues/11.
