### PR TITLE
Update base bounds

### DIFF
--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -22,6 +22,7 @@ tested-with:         GHC == 8.8.4
                    , GHC == 9.8.2
                    , GHC == 9.10.2
                    , GHC == 9.12.2
+                   , GHC == 9.14.1
 
 source-repository head
     type: git

--- a/hoist-error.cabal
+++ b/hoist-error.cabal
@@ -25,13 +25,13 @@ tested-with:         GHC == 8.8.4
 
 source-repository head
     type: git
-    location: https://github.com/alephcloud/hs-hoist-error.git
+    location: https://github.com/qfpl/hs-hoist-error.git
 
 library
   exposed-modules:
     Control.Monad.Error.Hoist
     Control.Monad.Fail.Hoist
-  build-depends:       base   >=4.13 && <4.22
+  build-depends:       base   >=4.13 && <4.23
                      , mtl    >=2.2 && <2.4
 
   hs-source-dirs:      src


### PR DESCRIPTION
This PR:
- relaxes the bounds for `base`
- sets up the correct github link for the repo
- adds GHC 9.14.1